### PR TITLE
Update Pydantic version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi~=0.75.0
 uvicorn==0.17.6
 wget==3.2
 numpy==1.22.4
-pydantic==1.9.1
+pydantic==v1.10.0a1
 torch
 torchvision
 Pillow==9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi~=0.75.0
 uvicorn==0.17.6
 wget==3.2
 numpy==1.22.4
-pydantic==1.9.1
+pydantic==1.10.0a1
 torch
 torchvision
 Pillow==9.1.1


### PR DESCRIPTION
Older versions of pydantic can have an issue with fastapi. See github thread [here](https://github.com/tiangolo/fastapi/issues/5048). Updating pydantic version to recommended version solved the issue for me